### PR TITLE
fix: ensure agd tx swingset install-bundle uses gas-adjustment 1.2

### DIFF
--- a/contract/scripts/install-bundles.sh
+++ b/contract/scripts/install-bundles.sh
@@ -9,7 +9,7 @@ cd /workspace/contract
 install_bundle() {
   ls -sh "$1"
   agd tx swingset install-bundle --compress "@$1" \
-    --from user1 --keyring-backend=test --gas=auto \
+    --from user1 --keyring-backend=test --gas=auto --gas-adjustment=1.2 \
     --chain-id=agoriclocal -bblock --yes -o json
 }
 


### PR DESCRIPTION
Needed for a successful `yarn start:contract` flow as described in #28 