### PR TITLE
build: avoid failure to delete Symbol.dispose using ses 0.18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "resolutions-note": "work-around for https://github.com/Agoric/agoric-sdk/issues/8621",
   "resolutions": {
-    "ses": "0.18.4",
+    "ses": "0.18.5",
     "@endo/bundle-source": "2.5.2-upstream-rollup",
     "@endo/captp": "3.1.1",
     "@endo/compartment-mapper": "0.8.4",


### PR DESCRIPTION
fixes #50
fixes #43 

## to test

Run thru the getting started process but use the `dc-dispose-fix` branch at the `yarn create` step:

```
yarn create @agoric/dapp --dapp-template dapp-offer-up --dapp-branch dc-dispose-fix demo
```


## diagnosis: SES 0.18.4 and node v18.19.0 don't get along

We have seen some issues near node v18.19.0:

 - https://github.com/Agoric/agoric-sdk/issues/8599

And now that version is in the `ghcr.io/agoric/agoric-sdk:39` image used in this dapp by way of agoric-3-proposals:

```
$ docker run --rm -ti --entrypoint=/bin/bash ghcr.io/agoric/agoric-sdk:39 
root@73e3f8a55f2a:~# node --version
v18.19.0
```

https://github.com/Agoric/agoric-sdk/blob/45a954cbcbb083e756e8244240818632c1277396/packages/deployment/Dockerfile.sdk#L33-L36

that takes us to...

https://github.com/nodejs/docker-node/blob/f416b53801a9d49d6ce6b2c038c8bc9ed93625dd/18/bullseye/Dockerfile#L6
```
ENV NODE_VERSION 18.19.0
```

## treatment: use 0.18.5

including a relevant fix: [9fb1242](https://github.com/endojs/endo/commit/9fb1242c3b48cdd363eecccc357f84f4d223ccc1)

reportedly 0.18.8 should work, but I haven't tested it.

