### PR TITLE
fix: use limited publishBrandInfo power, not all of chainStorage

### DIFF
--- a/contract/Makefile
+++ b/contract/Makefile
@@ -113,9 +113,12 @@ install-bundles: bundles/bundle-list
 
 build-proposal: bundles/bundle-list
 
-bundles/bundle-list $(SCRIPT) $(PERMIT):
+bundles/bundle-list $(SCRIPT) $(PERMIT): ./scripts/build-contract-deployer.js ./scripts/build-proposal.sh
 	./scripts/build-proposal.sh
 
+./scripts/build-contract-deployer.js: offer-up-proposal.js
+
+offer-up-proposal.js: platform-goals/boardAux.js platform-goals/marshal-produce.js
 
 clean:
 	@rm -rf $(SCRIPT) $(PERMIT) bundles/

--- a/contract/src/platform-goals/boardAux.js
+++ b/contract/src/platform-goals/boardAux.js
@@ -1,0 +1,114 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+
+const { Fail } = assert;
+
+// vstorage paths under published.*
+const BOARD_AUX = 'boardAux';
+
+/**
+ * @param {import('@agoric/zone').Zone} zone
+ * @param {Marshaller} marshalData
+ * @param {{
+ *   board: ERef<import('./core-types').Board>;
+ *   chainStorage: ERef<StorageNode>;
+ * }} powers
+ */
+export const makeBoardAuxManager = (zone, marshalData, powers) => {
+  const { board, chainStorage } = powers;
+  const store = zone.mapStore('boardAux');
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+
+  const formatValue = value => {
+    const aux = marshalData.toCapData(value);
+    // max length?
+    return JSON.stringify(aux);
+  };
+
+  const boardAuxNode = key =>
+    E.when(E(board).getId(key), boardId => E(boardAux).makeChildNode(boardId));
+
+  const init = async (key, value) => {
+    store.init(key, value);
+    await E(boardAuxNode(key)).setValue(formatValue(value));
+  };
+
+  const update = async (key, value) => {
+    if (store.has(key)) {
+      store.set(key, value);
+    } else {
+      store.init(key, value);
+    }
+    await E(boardAuxNode(key)).setValue(formatValue(value));
+  };
+
+  /**
+   * Publish displayInfo of a brand to vstorage under its boardId.
+   *
+   * Works only once per brand.
+   * @see {BoardAuxAdmin} to over-write aux info
+   *
+   * @param {Brand} brand
+   */
+  const publishBrandInfo = brand =>
+    E.when(
+      Promise.all([E(brand).getAllegedName(), E(brand).getDisplayInfo()]),
+      ([allegedName, displayInfo]) =>
+        init(brand, harden({ allegedName, displayInfo })),
+    );
+
+  return harden({
+    brandAuxPublisher: Far('BrandAuxPublisher', { publishBrandInfo }),
+    boardAuxTOFU: Far('BoardAuxTOFU', { publishBrandInfo, init }),
+    boardAuxAdmin: Far('BoardAuxAdmin', { publishBrandInfo, init, update }),
+  });
+};
+/** @typedef {ReturnType<typeof makeBoardAuxManager>} BoardAuxManager */
+
+/** @typedef {BoardAuxManager['brandAuxPublisher']} BrandAuxPublisher */
+/** @typedef {BoardAuxManager['boardAuxTOFU']} BoardAuxTOFU */
+/** @typedef {BoardAuxManager['boardAuxAdmin']} BoardAuxAdmin */
+
+/**
+ * @typedef {import('./core-types').PromiseSpaceOf<{
+ *   brandAuxPublisher: BrandAuxPublisher;
+ *   boardAuxTOFU: BoardAuxTOFU;
+ *   boardAuxAdmin: BoardAuxAdmin;
+ * }>} BoardAuxPowers
+ */
+
+/**
+ * @param {import('./core-types').BootstrapPowers
+ *   & import('./marshal-produce').Endo1Space
+ *   & BoardAuxPowers
+ * } powers
+ */
+export const produceBoardAuxManager = async powers => {
+  const { zone } = powers;
+  const { board, chainStorage, endo1 } = powers.consume;
+  const { marshal } = await endo1;
+  const { makeMarshal } = marshal;
+  const marshalData = makeMarshal(_val => Fail`data only`);
+
+  const mgr = makeBoardAuxManager(zone, marshalData, { board, chainStorage });
+  powers.produce.brandAuxPublisher.reset();
+  powers.produce.boardAuxTOFU.reset();
+  powers.produce.boardAuxAdmin.reset();
+  powers.produce.brandAuxPublisher.resolve(mgr.brandAuxPublisher);
+  powers.produce.boardAuxTOFU.resolve(mgr.boardAuxTOFU);
+  powers.produce.boardAuxAdmin.resolve(mgr.boardAuxAdmin);
+};
+
+export const permit = {
+  zone: true,
+  consume: { board: true, chainStorage: true, endo1: true },
+  produce: {
+    brandAuxPublisher: true,
+    boardAuxTOFU: true,
+    boardAuxAdmin: true,
+  },
+};
+
+export const manifest = {
+  [produceBoardAuxManager.name]: permit,
+};

--- a/contract/src/platform-goals/core-types.d.ts
+++ b/contract/src/platform-goals/core-types.d.ts
@@ -1,0 +1,58 @@
+import type { Zone } from '@agoric/zone';
+
+// XXX how to import types from @agoric/vats?
+// cf. https://github.com/Agoric/agoric-sdk/blob/master/packages/vats/src/core/types-ambient.d.ts
+type Board = { getId: (key: unknown) => string };
+
+type WellKnown = {
+  asset: 'BLD' | 'IST';
+  contract: 'VaultFactory' | 'FeeDistributor';
+};
+
+// TODO: include AssetKind { IST: 'nat', ... }
+type AssetsSpace<T extends string> = {
+  brand: PromiseSpaceOf<Record<T, Brand>>;
+  issuer: PromiseSpaceOf<Record<T, Issuer>>;
+};
+
+// TODO: include contract start function types
+type ContractSpace<T extends string> = {
+  installation: PromiseSpaceOf<Record<T, Installation>>;
+  instance: PromiseSpaceOf<Record<T, Instance>>;
+};
+
+type WellKnownSpaces = AssetsSpace<WellKnown['asset']> &
+  ContractSpace<WellKnown['contract']>;
+
+type BootstrapSpace = PromiseSpaceOf<{
+  chainStorage: StorageNode;
+  board: Board;
+  startUpgradable: (...args: unknown[]) => any;
+  zoe: ZoeService;
+}>;
+
+type BootstrapPowers = BootstrapSpace &
+  WellKnownSpaces & {
+    zone: Zone;
+  };
+
+type Producer<T> = {
+  resolve: (v: ERef<T>) => void;
+  reject: (r: unknown) => void;
+  reset: (reason?: unknown) => void;
+};
+
+/**
+ * @template B - Bidirectional
+ * @template C - Consume only
+ * @template P - Produce only
+ */
+type PromiseSpaceOf<B, C = {}, P = {}> = {
+  consume: { [K in keyof (B & C)]: Promise<(B & C)[K]> };
+  produce: { [K in keyof (B & P)]: Producer<(B & P)[K]> };
+};
+
+type BootstrapManifestPermit =
+  | true
+  | string
+  | { [key: string]: BootstrapManifestPermit };

--- a/contract/src/platform-goals/marshal-produce.js
+++ b/contract/src/platform-goals/marshal-produce.js
@@ -1,0 +1,34 @@
+// @ts-check
+import * as marshal from '@endo/marshal';
+import * as patterns from '@endo/patterns';
+
+/**
+ * @typedef {{
+ *   endo1: {
+ *     marshal: typeof import('@endo/marshal');
+ *     patterns: typeof import('@endo/patterns');
+ *   }
+ * }} Endo1Modules
+ * @typedef {import('./core-types').PromiseSpaceOf<Endo1Modules>} Endo1Space
+ */
+
+/**
+ * Make @endo/marshal, @endo/patterns available to CoreEval scripts.
+ *
+ * @param {import('./core-types').BootstrapPowers & Endo1Space} permittedPowers
+ */
+export const produceEndoModules = permittedPowers => {
+  const { produce } = permittedPowers;
+  const endo = { marshal, patterns };
+  produce.endo1.resolve(endo);
+};
+
+/** @type {import('./core-types').BootstrapManifestPermit} */
+export const permit = {
+  /** @type {Record<keyof Endo1Modules, true>} */
+  produce: { endo1: true },
+};
+
+export const manifest = {
+  [produceEndoModules.name]: permit,
+};


### PR DESCRIPTION
fixes #59 

We produce a new `publishBrandInfo` power (**feat**) and use it to reduce the power granted to dapp-offer-up's core eval script (**fix**).

Along the way, we likewise make `makeMarshal` available via the promise space (_perhaps should be its own feat?_).

## Testing Considerations

Until we have something like #46 , I hope reviewers will do a bit of manual testing.