### PR TITLE
chore: add SKIP_EXTENSION_SETUP flag to avoid duplicate wallet setup

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "test": "vitest spec",
-    "test:e2e": "EXTENSION=keplr synpress run --configFile=test/e2e/synpress.config.cjs",
+    "test:e2e": "SKIP_EXTENSION_SETUP=true EXTENSION=keplr synpress run --configFile=test/e2e/synpress.config.cjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "yarn lint --fix",
     "preview": "vite preview"


### PR DESCRIPTION
In end-to-end test cases, the wallet is set up twice because `@agoric/synpress` has code in the `before` hook that sets up the wallet before running tests. [Check the code here](https://github.com/agoric-labs/synpress/blob/dev/support/index.js#L33-L35C15).

However, since there is a specific test for setting up the wallet in `dapp-offer-up` [in this file](https://github.com/Agoric/dapp-offer-up/blob/main/ui/test/e2e/specs/test.spec.js#L5-L16C8), we can skip the setup done by `@agoric/synpress` by setting the `SKIP_EXTENSION_SETUP` environment variable to true. This avoids redundant wallet setups.