### PR TITLE
docs: Added a description of Offer Up and instructions to install in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # Agoric Dapp Starter: Offer Up
 
-This is a simple app for the [Agoric smart contract platform](https://docs.agoric.com/).
+Offer Up is a simple Dapp for the [Agoric smart contract platform](https://docs.agoric.com/) that permits users to explore items for sale in a marketplace, displaying default options of maps, potions, and scrolls. Users can select up to three items in any combination, create an offer starting from 0.25 [IST](https://agoric.com/blog/getting-started/ist), and upon transaction confirmation, receive the chosen items in their wallet while the offered amount is deducted from their balance.
 
-<img alt="Vite + React + Agoric page with Connect Wallet button"
-style="border: 1px solid" width="300"
-src="https://docs.agoric.com/assets/img/new_002_small2.2dfb7462.png" />
-
-The contract lets you make an offer to give a small amount of [IST](https://inter.trade/) in exchange for
-a few NFTs.
+<div style="display: flex; align-items: center; justify-content: center; height: 300;">
+    <img src="https://docs.agoric.com/assets/new_002_small2.DgAL2zV8.png" alt="Offer Up Dapp" style="display: block; margin: auto;">
+</div>
 
 ## Getting started
 
-See [Your First Agoric Dapp](https://docs.agoric.com/guides/getting-started/) tutorial.
+Detailed instructions regarding setting up the environment with a video walkthrough is available at [Your First Agoric Dapp](https://docs.agoric.com/guides/getting-started/) tutorial. But if you have the environment set, i.e., have correct version of node, yarn, docker, and Keplr wallet installed, here are the steps that you need to follow:
+- run the `yarn install` command to install any solution dependencies. *Downloading all the required dependencies may take several minutes. The UI depends on the React framework, and the contract depends on the Agoric framework. The packages in this project also have development dependencies for testing, code formatting, and static analysis.*
+- start a local Agoric blockchain using the `yarn start:docker` command.
+- run `yarn docker:logs` to check the logs. Once your logs resemble the following, stop the logs by pressing `ctrl+c`.
+```
+demo-agd-1  | 2023-12-27T04:08:06.384Z block-manager: block 1003 begin
+demo-agd-1  | 2023-12-27T04:08:06.386Z block-manager: block 1003 commit
+demo-agd-1  | 2023-12-27T04:08:07.396Z block-manager: block 1004 begin
+demo-agd-1  | 2023-12-27T04:08:07.398Z block-manager: block 1004 commit
+demo-agd-1  | 2023-12-27T04:08:08.405Z block-manager: block 1005 begin
+demo-agd-1  | 2023-12-27T04:08:08.407Z block-manager: block 1005 commit
+```
+- run `yarn start:contract` to start the smart contract. 
+- run `yarn start:ui` to start the smart contract. You can use the link in the output to load the smart contract UI in a browser.
 
-## Contributing: Development, Testing
+For any troubleshooting please refer to the detailed tutorial at [Here](https://docs.agoric.com/guides/getting-started/).
 
-The UI is a React app started with the [vite](https://vitejs.dev/) `react-ts` template.
-On top of that, we add
+## Testing
 
-- Watching [blockchain state queries](https://docs.agoric.com/guides/getting-started/contract-rpc.html#querying-vstorage)
-- [Signing and sending offers](https://docs.agoric.com/guides/getting-started/contract-rpc.html#signing-and-broadcasting-offers)
+To run the unit test:
+- run `yarn test` to run the unit tests
 
-See [CONTRIBUTING](./CONTRIBUTING.md) for more on testing.
+To run the end to end test:
+- run `yarn test:e2e --browser chrome` to run the end to end tests; you may replace `chrome` with your favorite browser name. Although `chrome` is the recommended browser to run end to end tests at this point.
+
+
+## Contributing
+
+See [CONTRIBUTING](./CONTRIBUTING.md) for more on contributing to this repo.

--- a/contract/test/test-build-proposal.js
+++ b/contract/test/test-build-proposal.js
@@ -20,7 +20,8 @@ test.only('proposal builder generates compressed bundles less than 1MB', async t
     const buffer = await t.context.compressFile(bundle);
     t.assert(buffer);
     const sizeInMb = buffer.length / (1024 * 1024);
-    t.assert(sizeInMb < 1, 'Compressed bundle is less than 1MB');
+    // JSON RPC hex encoding doubles the size
+    t.assert(sizeInMb * 2 < 1, 'Compressed bundle is less than 0.5MB');
     t.log({
       bundleId: bundle.split('cache/')[1].split('.json')[0],
       compressedSize: `${sizeInMb} MB`,


### PR DESCRIPTION
The ReadMe.md file at the root is edited. Here is a summary:

1. A proper description of the repo was missing from the `readme.md` so I used a paraphrased version of the description provided in the [`getting-started` tutorial](https://docs.agoric.com/guides/getting-started/). 
2. The link to image "https://docs.agoric.com/assets/img/new_002_small2.2dfb7462.png" was broken. It is replaced with an [image of the dapp UI](https://docs.agoric.com/assets/new_002_small2.DgAL2zV8.png).
3. I expanded a bit on the getting started subsection. A concise version of the instructions to install and start contract are provided. This is again a summarized version of the instructions provided in the tutorial.
4. In the testing section of the readme.md file, instructions to run unit tests and end-to-end tests is provided. 
5. The links provided in Contributing subsections were a bit confusing to new devs therefore they are removed.

