### PR TITLE
Using/Teaching `zone.exo` instead of `Far`

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -47,7 +47,9 @@
   },
   "dependencies": {
     "@agoric/ertp": "^0.16.3-u12.0",
+    "@agoric/vat-data": "0.5.3-u16.1",
     "@agoric/zoe": "^0.26.3-u12.0",
+    "@agoric/zone": "dev",
     "@endo/far": "^0.2.22",
     "@endo/marshal": "^0.8.9",
     "@endo/patterns": "^0.2.5"

--- a/contract/src/offer-up.contract.js
+++ b/contract/src/offer-up.contract.js
@@ -19,14 +19,15 @@
  */
 // @ts-check
 
-import { Far } from '@endo/far';
+// import { Far } from '@endo/far';
 import { M, getCopyBagEntries } from '@endo/patterns';
 import { AssetKind } from '@agoric/ertp/src/amountMath.js';
 import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
 import { atomicRearrange } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
 import '@agoric/zoe/exported.js';
-
+import { makeDurableZone } from '@agoric/zone/durable.js';
 const { Fail, quote: q } = assert;
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 // #region bag utilities
 /** @type { (xs: bigint[]) => bigint } */
@@ -71,6 +72,16 @@ export const customTermsShape = meta.customTermsShape;
  */
 export const start = async zcf => {
   const { tradePrice, maxItems = 3n } = zcf.getTerms();
+
+  /**
+   * TODO: below is somewhat fake way of generating a zone. This should be fixed by passing it as a parameter.
+   * RN I don't know how to do it.
+   */
+  const baggage = makeScalarBigMapStore('baggage', {
+    keyShape: M.string(),
+    durable: true,
+  });
+  const zone = makeDurableZone(baggage);
 
   /**
    * a new ERTP mint for items, accessed thru the Zoe Contract Facet.
@@ -133,7 +144,8 @@ export const start = async zcf => {
     zcf.makeInvitation(tradeHandler, 'buy items', undefined, proposalShape);
 
   // Mark the publicFacet Far, i.e. reachable from outside the contract
-  const publicFacet = Far('Items Public Facet', {
+  // const myexo = makeExo('Items Public Facet', undefined);
+  const publicFacet = zone.exo('Items Public Facet', undefined, {
     makeTradeInvitation,
   });
   return harden({ publicFacet });


### PR DESCRIPTION
This adds code to contract file (and related deps to package.json) to use `zone.exo` to replace `Far`. Note that this is only for teaching purpose at the moment and does not make resulting contract upgradable because `zone` and `baggage` are created inside `start` function. The upgradability will require changing `start` signature which I am avoiding at the moment. 


**Ref(s):**
https://github.com/Agoric/documentation/issues/1033

