### PR TITLE
Adding `contract/,tx.json` and `.yarn/install-state.gz` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ dist-ssr
 # Synpress directories and files
 screenshots
 videos
+
+# Yarn related
+.yarn/install-state.gz
+
+# contract tx
+contract/,tx.json


### PR DESCRIPTION
Added following text to `.gitignore`:

```

# Yarn related
.yarn/install-state.gz

# contract tx
contract/,tx.json
```