### PR TITLE
Remove Unused `lower-bundle-cost` Proposal Code

### DIFF
--- a/contract/Makefile
+++ b/contract/Makefile
@@ -27,40 +27,6 @@ mint100:
 		yarn --silent agops vaults open --wantMinted 100 --giveCollateral 100 >/tmp/want-ist.json && \
 		yarn --silent agops perf satisfaction --executeOffer /tmp/want-ist.json --from user1 --keyring-backend=test
 
-# https://agoric.explorers.guru/proposal/61
-lower-bundle-cost: bundles/lower-bundle-cost.json ./scripts/voteLatestProposalAndWait.sh
-	agd tx gov submit-proposal param-change bundles/lower-bundle-cost.json \
-	$(SIGN_BROADCAST_OPTS) \
-	--from user1
-	./scripts/voteLatestProposalAndWait.sh
-	# agd query swingset params
-
-
-bundles/swingset-params.json:
-	mkdir -p bundles/
-	agd query swingset params -o json >$@
-
-.ONESHELL:
-bundles/lower-bundle-cost.json: bundles/swingset-params.json
-	@read PARAMS < bundles/swingset-params.json; export PARAMS
-	node - <<- EOF >$@
-		const storageByte = '20000000';
-		const paramChange = {
-			title: 'Lower Bundle Cost to 0.02 IST/Kb (a la mainnet 61)',
-			description: '0.02 IST/Kb',
-			deposit: '10000000ubld',
-			changes: [{
-				subspace: 'swingset',
-				key: 'beans_per_unit',
-				value: '...',
-			}],
-		};
-		const params = JSON.parse(process.env.PARAMS);
-		const ix = params.beans_per_unit.findIndex(({key}) => key === 'storageByte');
-		params.beans_per_unit[ix].beans = storageByte;
-		paramChange.changes[0].value = params.beans_per_unit;
-		console.log(JSON.stringify(paramChange, null, 2));
-	EOF
 
 # Keep mint4k around a while for compatibility
 mint4k:

--- a/contract/scripts/run-chain.sh
+++ b/contract/scripts/run-chain.sh
@@ -9,7 +9,6 @@
 waitForBlock 1
 
 make -C /workspace/contract mint100
-make -C /workspace/contract lower-bundle-cost
 
 # bring back chain process to foreground
 wait


### PR DESCRIPTION
Closes #96 

Removes command from `contract/scripts/run-chain.sh` and related targets from `contract/Makefile`. Replaying `lower-bundle-cost` is not needed as bundle cost is already as intended in the latest `a3p` images used by `dapp-offer-up`.